### PR TITLE
8.3: Update sources tarball to v8.74.6.0

### DIFF
--- a/SOURCES/qlogic-fastlinq-8.70.12.0.tar.gz
+++ b/SOURCES/qlogic-fastlinq-8.70.12.0.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:835d5d43a6b8d82f8b8b135022deebe27d8f512752aa75129908c37a3e8a309c
-size 7792276

--- a/SOURCES/qlogic-fastlinq-8.74.6.0.tar.gz
+++ b/SOURCES/qlogic-fastlinq-8.74.6.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:00d7c604eb9756a7b6f89eab3ea72f3df4959e89aa6ec2ac954c9ab35049ac59
+size 7953233

--- a/SPECS/qlogic-fastlinq-alt.spec
+++ b/SPECS/qlogic-fastlinq-alt.spec
@@ -7,12 +7,12 @@
 
 Summary: %{vendor_name} %{driver_name} device drivers
 Name: %{vendor_label}-%{driver_name}-alt
-Version: 8.70.12.0
+Version: 8.74.6.0
 Release: 1%{?dist}
 License: GPL
 
 # Extracted from latest XS driver disk
-Source0: qlogic-fastlinq-8.70.12.0.tar.gz
+Source0: qlogic-fastlinq-%{version}.tar.gz
 
 BuildRequires: gcc
 BuildRequires: kernel-devel
@@ -64,5 +64,8 @@ install -m 755 $(pwd)/qed-%{version}/src/qed_init_values_zipped-*.bin %{buildroo
 /lib/modules/%{kernel_version}/*/*.ko
 
 %changelog
+* Fri Apr 17 2026 Thierry Escande <thierry.escande@vates.tech> 8.74.6.0-1
+- Update to sources v8.74.6.0
+
 * Mon Jul 03 2023 Gael Duperrey <gduperrey@vates.fr> - 8.70.12.0-1
 - initial package, version 8.70.12.0


### PR DESCRIPTION
### Main information

#### Work Item Reference

<!-- If this change is related to a Vates internal task or issue,
please provide a work item reference (e.g., XCPNG-12345), Otherwise,
remove this section and the next one. -->

XCPNG-3200

#### Related changes (optional)

<!--When several PRs are part of a single changeset, you can either fill
the form for each PR, or just once and link towards the PR with the filled
form. In the reference PR, the one with the form filled in, list all related
PRs.

You can also mention here constraints between PRs, if useful:
merge/build order, chained builds...-->

N/A

#### Context & Motivation

<!-- Explain the context of the change, without assuming that the reviewers
know about it.  and why it would be good to accept
it as an update to XCP-ng? What problem does it solve, or benefit does it
bring. Are there known or envisioned drawbacks?

In case of an update based on an upstream's update,
the motivation, the problem being solved, or the benefit to users or
maintainers. Provide any necessary context, without assuming that the
reviewers know about it. -->

The main package for the qlogic-fastlinq driver has been reported to not work properly with some recent hardware firmwares.

It's been decided to keep the XS version for the main package and update this `-alt` version to the latest version available from the manufacturer, i.e. v8.74.6.0.

If the tests done by concerned customers do not show any regression the main package could be updated to this version as well.

Among a lot of cosmetic changes in the sources and support for new kernel versions, this update includes 2 fixes for the qede driver:
- Driver does not retain configured MAC and MTU post reset recovery
- Driver does not recover from TX timeout error

#### Release Target

- [x] We already defined a release target with the release team.
- [ ] I haven't talked with the release team, but I have a proposed target.
- [ ] I'm not sure, let's talk about it.

<!-- Unless you have chosen "I'm not sure", you can specify the wanted release
target here: fast track, 8.3-next, 8.3-next+1, other specific target. For members
of Vates' XCP-ng team: the reference for this information is the related work
item's milestone. -->

To limit the impact on users that have installed the `-alt` package let's target `8.3-next+1` and leave time to volunteers to test it. Seen with Samuel.

---

### Release Notes and Documentation

#### Explain the change to users

<!-- Write a user-facing explanation that will serve as a basis for public
announcements. Explain what has changed, what the consequences are
for users (main bugs fixed, new features, etc.).  It is not a technical changelog. -->

Fixes 2 issues in the qede module driver:
- Driver does not retain configured MAC and MTU post reset recovery
- Driver does not recover from TX timeout error

#### Attention points

<!-- Consequences of the changes on existing setups. Include any manual steps,
changes to default behavior, compatibility issues, etc. Anything that we should
bring to the attention of user or people offering technical support -->

This will impact users that have installed this `-alt` package to downgrade the driver due to issues with the main one. Their driver will be updated from `8.70.12.0` to `8.74.6.0`.

#### Documentation update needed

- [x] Yes
- [ ] No
- [ ] I'm not sure, help me

<!-- If yes, explain what needs to be updated and where. If no, explain why so that
the reviewer can understand the reason. -->

<!-- Add links to the documentation update PRs if/when they are created. -->

[Driver versions wiki](https://github.com/xcp-ng/xcp/wiki/Drivers) updated accordingly

---

### Testing and regression avoidance

<!-- Consider the change itself, but also regressions that could be caused
unwillingly by the change, due to what components or code paths were touched.
It's the right time to be paranoid. Consider what could go wrong in the
worst case. -->

#### What tests have you performed?

Modules loading only (no hardware available for further testing)

#### What manual tests should be performed after the build, and by whom?

<!-- Manual tests that should be repeated after the build (always consider that tests
performed before the build are not definitive proof), plus tests that we should invite
the user community to perform. -->

Ask concerned customers to test this release

#### What's covered by the xcp-ng-tests test suite?

<!-- If you don't know, it's the perfect time to ask someone about it, and/or to dig into
the test suite. If there are any tests that you'd like to run before the merge rather than
after, mention them too. -->

N/A

#### What tests have been or will be added to CI for this change? If none, explain why.

None, it's a device driver for hardware we don't have

---

### Xen Orchestra Impact

#### Does this affect existing features in Xen Orchestra, or add new features that could be useful?

- [ ] Yes
- [x] No

<!-- If this affects existing features, describe which features are affected and how.
If this adds new features that Xen Orchestra could leverage (not just in the UI.

There's also the back-end and the REST API), describe them. -->
